### PR TITLE
getting ca.pem to work in serverless function

### DIFF
--- a/pages/api/email-lookup.js
+++ b/pages/api/email-lookup.js
@@ -3,7 +3,7 @@ import prisma from '../../lib/prisma';
 const findUserByEmail = async (email) => {
 
   const fs = require('fs')
-  const path = './prisma'
+  const path = '/tmp'
 
   try {
     if (fs.existsSync(`${path}/ca.pem`)) {

--- a/pages/api/email-lookup.js
+++ b/pages/api/email-lookup.js
@@ -3,10 +3,10 @@ import prisma from '../../lib/prisma';
 const findUserByEmail = async (email) => {
 
   const fs = require('fs')
-  const path = './prisma/ca.pem'
+  const path = './prisma'
 
   try {
-    if (fs.existsSync(path)) {
+    if (fs.existsSync(`${path}/ca.pem`)) {
       // ca file exists
 
       // do nothing
@@ -15,8 +15,10 @@ const findUserByEmail = async (email) => {
       // ca file not exists
 
       // creates ca.pem file from ENV
+
+      fs.mkdirSync(path, { recursive: true })
       
-      fs.writeFileSync(path, process.env.CA_PEM)
+      fs.writeFileSync(`${path}/ca.pem`, process.env.CA_PEM)
     }
   } catch(err) {
     console.error(err)

--- a/pages/api/email-lookup.js
+++ b/pages/api/email-lookup.js
@@ -1,6 +1,27 @@
 import prisma from '../../lib/prisma';
 
 const findUserByEmail = async (email) => {
+
+  const fs = require('fs')
+  const path = './prisma/ca.pem'
+
+  try {
+    if (fs.existsSync(path)) {
+      // ca file exists
+
+      // do nothing
+
+    } else {
+      // ca file not exists
+
+      // creates ca.pem file from ENV
+      
+      fs.writeFileSync(path, process.env.CA_PEM)
+    }
+  } catch(err) {
+    console.error(err)
+  }
+
   const user = await prisma.user.findUnique({
     where: {
       email: email,


### PR DESCRIPTION
Since prisma expects a certificate to be used to encrypt the database connection and that it is not a good practice to commit the certificate inside git, the certificate needs to be stored inside ENV (CA_PEM) and be generated inside `/tmp/ca.pem` when the serverless function cold boot (if warm boot, the certificate will already be generated at `/tmp/ca.pem` from original cold boot).

The reason we need to put the ca file in `/tmp` is because this is the only writable directory in a serverless function.

Note:
1. populate CA_PEM env with content of ca.pem
2. update the DATABASE_URL env to load cert from `/tmp`, i.e. replace `&sslcert=ca.pem` with `&sslcert=/tmp/ca.pem`.


Test:
POST https://vercel-scalegrid-error.vercel-support.app/api/email-lookup with 
```
{"email": "test@example.com"}
```

![image](https://user-images.githubusercontent.com/179761/119932421-db0d4d80-bfb5-11eb-91e4-c079fbf60161.png)


** Lastly **
You might want to consult the Prisma guide to see if they support loading cert directly from ENV (very likely supported). As this will allow the very to be loaded directly from ENV save us some extra disk I/O.


** Update **
Seems what I mentioned in the section above is being worked on https://github.com/prisma/prisma/issues/1673